### PR TITLE
Base UI changes

### DIFF
--- a/src/canvas.c
+++ b/src/canvas.c
@@ -1836,7 +1836,7 @@ static void fs_ok(fselector_dd *dt, void **wdata)
 		{
 			ext = file_formats[settings.ftype].ext;
 			if (!ext[0]) break;
-		
+
 			if (c) /* There is an extension */
 			{
 				/* Same extension? */
@@ -2315,7 +2315,7 @@ void realign_size()		// Reapply old zoom
 	 * is the actual resize; so to communicate new position to that latter
 	 * resize, I preset both position and range of CSCROLL here - WJ */
 	cmd_setv(scrolledwindow_canvas, xywh, CSCROLL_XYRANGE);
- 
+
 	cmd_setv(drawing_canvas, xywh + 2, CANVAS_SIZE);
 	vw_focus_view();	// View window position may need updating
 	toolbar_zoom_update();	// Zoom factor may have been reset
@@ -2849,7 +2849,7 @@ void do_tool_action(int cmd, int x, int y, int pressure)
 		}
 
 		// Do memory stuff for undo
-		mem_undo_next(UNDO_TOOL);	
+		mem_undo_next(UNDO_TOOL);
 
 		/* Handle continuous mode */
 		if (mem_continuous && !first_point)
@@ -2947,7 +2947,7 @@ void do_tool_action(int cmd, int x, int y, int pressure)
 			i = abs(x - tool_ox);
 			j = abs(y - tool_oy);
 			len1 = sqrt(i * i + j * j) / (i > j ? i : j);
-			
+
 			while (TRUE)
 			{
 				if (lstep + (1.0 / 65536.0) >= brush_spacing)
@@ -3515,7 +3515,7 @@ void create_default_image()			// Create default new image
 	int	nw = inifile_get_gint32("lastnewWidth", DEFAULT_WIDTH ),
 		nh = inifile_get_gint32("lastnewHeight", DEFAULT_HEIGHT ),
 		nc = inifile_get_gint32("lastnewCols", 256 ),
-		nt = inifile_get_gint32("lastnewType", 2 );
+		nt = inifile_get_gint32("lastnewType", 0 );
 
 	do_new_one(nw, nh, nc, nt == 1 ? NULL : mem_pal_def,
 		(nt == 0) || (nt > 2) ? 3 : 1, FALSE);

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -2568,6 +2568,15 @@ static int tool_draw(int x, int y, int first_point, int *update)
 	case TOOL_CIRCLE:
 		f_circle(x, y, tool_size);
 		break;
+	case TOOL_FUZZYCIRCLE:
+		f_fuzzycircle(x, y, tool_size);
+		break;
+	case TOOL_GRADIENTCIRCLE:
+		f_gradientcircle(x, y, tool_size);
+		break;
+	case TOOL_CIRCLE_OUTLINE:
+		f_circle_outline(x, y, tool_size);
+		break;
 	case TOOL_HORIZONTAL:
 		miny = y; yh = 1;
 		sline(x - ts2, y, x + tr2, y);
@@ -2875,6 +2884,33 @@ void do_tool_action(int cmd, int x, int y, int pressure)
 					f_circle(tool_ox, tool_oy, tool_size);
 				tline(tool_ox, tool_oy, x, y, tool_size);
 				f_circle(x, y, tool_size);
+				break;
+			}
+			if (tool_type == TOOL_FUZZYCIRCLE)
+			{
+				/* Redraw stroke gradient in proper direction */
+				if (STROKE_GRADIENT)
+					f_fuzzycircle(tool_ox, tool_oy, tool_size);
+				tline(tool_ox, tool_oy, x, y, tool_size);
+				f_fuzzycircle(x, y, tool_size);
+				break;
+			}
+			if (tool_type == TOOL_GRADIENTCIRCLE)
+			{
+				/* Redraw stroke gradient in proper direction */
+				if (STROKE_GRADIENT)
+					f_gradientcircle(tool_ox, tool_oy, tool_size);
+				tline(tool_ox, tool_oy, x, y, tool_size);
+				f_gradientcircle(x, y, tool_size);
+				break;
+			}
+			if (tool_type == TOOL_CIRCLE_OUTLINE)
+			{
+				/* Redraw stroke gradient in proper direction */
+				if (STROKE_GRADIENT)
+					f_circle_outline(tool_ox, tool_oy, tool_size);
+				tline(tool_ox, tool_oy, x, y, tool_size);
+				f_circle_outline(x, y, tool_size);
 				break;
 			}
 			if (tool_type == TOOL_HORIZONTAL)

--- a/src/main.c
+++ b/src/main.c
@@ -437,6 +437,12 @@ int main( int argc, char *argv[] )
 	if ( new_empty )		// If no file was loaded, start with a blank canvas
 	{
 		create_default_image();
+
+		mem_col_[0] = 0;
+		mem_col_[1] = 4;
+		mem_col_24[0] = mem_pal[0];
+		mem_col_24[1] = mem_pal[4];
+		update_stuff(UPD_AB);
 	}
 
 	update_menus();

--- a/src/main.c
+++ b/src/main.c
@@ -438,6 +438,11 @@ int main( int argc, char *argv[] )
 	{
 		create_default_image();
 
+		mem_col_[0] = 7;
+		mem_col_24[0] = mem_pal[7];
+		update_stuff(UPD_AB);
+		flood_fill(1,1, get_pixel(4,4));
+
 		mem_col_[0] = 0;
 		mem_col_[1] = 4;
 		mem_col_24[0] = mem_pal[0];

--- a/src/memory.h
+++ b/src/memory.h
@@ -69,6 +69,10 @@ enum {
 	TOOL_POLYGON,
 	TOOL_CLONE,
 	TOOL_GRADIENT,
+	TOOL_FUZZYCIRCLE,
+	TOOL_GRADIENTCIRCLE,
+	TOOL_CIRCLE_OUTLINE,
+
 
 	TOTAL_CURSORS
 };
@@ -838,6 +842,9 @@ void g_para( int x1, int y1, int x2, int y2, int xv, int yv );	// Draw general p
 void f_rectangle( int x, int y, int w, int h );			// Draw a filled rectangle
 void f_circle( int x, int y, int r );				// Draw a filled circle
 void mem_ellipse( int x1, int y1, int x2, int y2, int thick );	// Thickness 0 means filled
+void f_fuzzycircle( int x, int y, int r );				// Draw a filled circle
+void f_gradientcircle( int x, int y, int r );				// Draw a filled circle
+void f_circle_outline( int x, int y, int r );				// Draw a filled circle
 
 // Draw whatever is bounded by two pairs of lines
 void draw_quad(linedata line1, linedata line2, linedata line3, linedata line4);

--- a/src/memory.h
+++ b/src/memory.h
@@ -30,8 +30,8 @@
  * !!! will have to be modified to use size_t instead */
 #define MAX_DIM (MAX_WIDTH > MAX_HEIGHT ? MAX_WIDTH : MAX_HEIGHT)
 
-#define DEFAULT_WIDTH 640
-#define DEFAULT_HEIGHT 480
+#define DEFAULT_WIDTH 800
+#define DEFAULT_HEIGHT 600
 
 /* Palette area layout */
 
@@ -337,7 +337,7 @@ int mem_undo_depth;				// Current undo depth
 
 image_info mem_image;			// Current image
 
-#define mem_img		mem_image.img		
+#define mem_img		mem_image.img
 #define mem_pal		mem_image.pal
 #define mem_cols	mem_image.cols
 #define mem_img_bpp	mem_image.bpp
@@ -709,7 +709,7 @@ int mem_dither(unsigned char *old, int ncols, short *dither, int cspace,
 int mem_dumb_dither(unsigned char *old, unsigned char *new, png_color *pal,
 	int width, int height, int ncols, int dither);
 //	Set up colors A, B, and pattern for dithering a given RGB color
-void mem_find_dither(int red, int green, int blue); 
+void mem_find_dither(int red, int green, int blue);
 //	Convert image to Indexed Palette using quantize
 int mem_quantize( unsigned char *old_mem_image, int target_cols, int type );
 void mem_invert();			// Invert the palette

--- a/src/otherwindow.c
+++ b/src/otherwindow.c
@@ -212,6 +212,11 @@ static void create_new(newwin_dd *dt, void **wdata)
 	if (im_type > 2); // Successfully done above
 	else if (new_window_type == 1) // Layer
 		layer_new(nw, nh, bpp, nc, pal, CMASK_IMAGE);
+
+		mem_col_[0] = 7;
+		mem_col_24[0] = mem_pal[7];
+		update_stuff(UPD_AB);
+		flood_fill(1,1, get_pixel(4,4));
 	else // Image
 	{
 		/* Nothing to undo if image got deleted already */
@@ -221,7 +226,7 @@ static void create_new(newwin_dd *dt, void **wdata)
 			/* System was unable to allocate memory for
 			 * image, using 8x8 instead */
 			nw = mem_width;
-			nh = mem_height;  
+			nh = mem_height;
 		}
 
 		inifile_set_gint32("lastnewWidth", nw );
@@ -676,7 +681,7 @@ static void brcosa_btn(brcosa_dd *dt, void **wdata, int what)
 
 	mem_pal_copy(mem_pal, dt->pal);
 
-	if (what == op_EVT_CANCEL); 
+	if (what == op_EVT_CANCEL);
 	else if (!dt->tmode) // OK/Apply
 	{
 		// !!! Buttons disabled for default values
@@ -987,7 +992,7 @@ static void click_sisca_centre(sisca_dd *dt, void **wdata)
 
 static char *bound_modes[] = { _("Mirror"), _("Tile"), _("Void") };
 static char *resize_modes[] = { _("Clear"), _("Tile"), _("Mirror tile"), NULL };
-static char *scale_modes[] = { 
+static char *scale_modes[] = {
 	_("Nearest Neighbour"),
 	_("Bilinear / Area Mapping"),
 	_("Bicubic"),

--- a/src/otherwindow.c
+++ b/src/otherwindow.c
@@ -211,12 +211,14 @@ static void create_new(newwin_dd *dt, void **wdata)
 	bpp = im_type == 0 ? 3 : 1;
 	if (im_type > 2); // Successfully done above
 	else if (new_window_type == 1) // Layer
+	{
 		layer_new(nw, nh, bpp, nc, pal, CMASK_IMAGE);
 
 		mem_col_[0] = 7;
 		mem_col_24[0] = mem_pal[7];
 		update_stuff(UPD_AB);
 		flood_fill(1,1, get_pixel(4,4));
+	}
 	else // Image
 	{
 		/* Nothing to undo if image got deleted already */


### PR DESCRIPTION
This is the first of a bunch of pull requests.  I have noticed that mtPaint is powerful and similar to tools such as Gimp.  However the UI is confusing.  Many of these pull requests should make it easy for people to transition and/or grasp mtPaint features.  If anything, the cleaner look should let users notice how powerful a tool mtPaint is.

This pull makes the default image white, with a larger default brush selected.  It also makes the image 24 bit so that effects, smudge tool, etc. are functional right away.  Finally, the default image is larger.  I thought it prudent to start off bigger so new users don't have possibly pixelated looking drawings.  Besides, it's easier to crop down with Delete than to size up.

OK, off to the next pull request.