### PR TITLE
Add various fixes

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,12 +8,14 @@ $(MAN_PAGE): mtpaint.pod
 	pod2man "--release=$(MT_VERSION)" "--date=$(MT_DATE)" "--center=Mark Tyler's Painting Program" mtpaint.pod > $(MAN_PAGE)
 
 install:
-	mkdir -p $(DESTDIR)$(MT_MAN_DEST)/man1 $(DESTDIR)$(MT_DATAROOT)/applications $(DESTDIR)$(MT_DATAROOT)/pixmaps
+	mkdir -p $(DESTDIR)$(MT_MAN_DEST)/man1 $(DESTDIR)$(MT_DATAROOT)/appdata $(DESTDIR)$(MT_DATAROOT)/applications $(DESTDIR)$(MT_DATAROOT)/pixmaps
 	cp $(MAN_PAGE) $(DESTDIR)$(MT_MAN_DEST)/man1
+	cp mtpaint.appdata.xml $(DESTDIR)$(MT_DATAROOT)/appdata
 	cp mtpaint.desktop $(DESTDIR)$(MT_DATAROOT)/applications
 	cp mtpaint.png $(DESTDIR)$(MT_DATAROOT)/pixmaps
 
 uninstall:
 	rm $(DESTDIR)$(MT_MAN_DEST)/man1/$(MAN_PAGE)
+	rm $(DESTDIR)$(MT_DATAROOT)/appdata/mtpaint.appdata.xml
 	rm $(DESTDIR)$(MT_DATAROOT)/applications/mtpaint.desktop
 	rm $(DESTDIR)$(MT_DATAROOT)/pixmaps/mtpaint.png

--- a/doc/mtpaint.appdata.xml
+++ b/doc/mtpaint.appdata.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 Ryan Lerch <rlerch@redhat.com> -->
+<!--
+EmailAddress: mtpaint-devel@lists.sourceforge.net
+SentUpstream: 2014-09-22
+-->
+<component type="desktop">
+  <id>mtpaint.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <name>mtPaint</name>
+  <summary>Painting program for creating icons and pixel-based artwork</summary>
+  <description>
+    <p>
+    mtPaint is a simple painting program designed for creating icons and pixel-based artwork.
+    It features a wide range of tools to help you create pixel art, including: a pixel-perfect grid, tools to make pixel gradients with the use of dithering, pixel brushes, and pixel line and shape tools.
+    It can edit indexed palette or 24 bit RGB images. Its main file format is PNG, although it can also handle JPEG, GIF, TIFF, BMP, XPM, and XBM files.
+    </p>
+  </description>
+  <launchable type="desktop-id">mtpaint.desktop</launchable>
+  <categories>
+    <category>Graphics</category>
+    <category>GTK</category>
+  </categories>
+  <kudos>
+    <kudo>UserDocs</kudo>
+  </kudos>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Main window</caption>
+      <image>https://raw.githubusercontent.com/hughsie/fedora-appstream/master/screenshots-extra/mtpaint/a.png</image>
+    </screenshot>
+  </screenshots>
+  <developer_name>Mark Tyler</developer_name>
+  <url type="bugtracker">https://github.com/wjaguar/mtPaint/issues</url>
+  <url type="help">http://mtpaint.sourceforge.net/handbook/en_GB/chap_00.html</url>
+  <url type="homepage">http://mtpaint.sourceforge.net</url>
+  <content_rating type="oars-1.0" />
+  <provides>
+    <binary>mtpaint</binary>
+  </provides>
+  <releases>
+    <release version="3.49.13" date="2017-10-20"/>
+  </releases>
+</component>

--- a/doc/mtpaint.desktop
+++ b/doc/mtpaint.desktop
@@ -9,5 +9,6 @@ TryExec=mtpaint
 Exec=mtpaint %F
 Icon=mtpaint
 Terminal=false
+StartupWMClass=mtpaint
 Categories=Graphics;2DGraphics;RasterGraphics;GTK;
 MimeType=image/bmp;image/x-bmp;image/x-ms-bmp;image/gif;image/jpeg;image/jpg;image/pjpeg;image/x-pcx;image/png;image/x-png;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-portable-pixmap;image/svg;image/svg+xml;image/x-tga;image/tiff;image/xbm;image/x-xbm;image/x-xbitmap;image/xpm;image/x-xpm;image/x-xpixmap;

--- a/src/mainwindow.c
+++ b/src/mainwindow.c
@@ -44,6 +44,8 @@
 #include "icons.h"
 #include "thread.h"
 
+#include <locale.h>
+
 
 typedef struct {
 	int idx_c, nidx_c, cnt_c;

--- a/src/png.c
+++ b/src/png.c
@@ -774,7 +774,7 @@ static int load_png(char *file_name, ls_settings *settings, memFILE *mf)
 	if (settings->bpp == 3)
 	{
 		png_set_strip_16(png_ptr);
-		png_set_gray_1_2_4_to_8(png_ptr);
+		png_set_expand_gray_1_2_4_to_8(png_ptr);
 		png_set_palette_to_rgb(png_ptr);
 		png_set_gray_to_rgb(png_ptr);
 
@@ -871,7 +871,7 @@ static int load_png(char *file_name, ls_settings *settings, memFILE *mf)
 		png_set_strip_alpha(png_ptr);
 		png_set_packing(png_ptr);
 		if ((color_type == PNG_COLOR_TYPE_GRAY) && (bit_depth < 8))
-			png_set_gray_1_2_4_to_8(png_ptr);
+			png_set_expand_gray_1_2_4_to_8(png_ptr);
 		for (i = 0; i < height; i++)
 		{
 			row_pointers[i] = settings->img[CHN_IMAGE] + i * width;

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -782,7 +782,7 @@ int run_def_action(int action, char *sname, char *dname, int delay)
 
 #else /* Linux */
 
-#define HANDBOOK_BROWSER "firefox"
+#define HANDBOOK_BROWSER "xdg-open"
 #define HANDBOOK_LOCATION "/usr/doc/mtpaint/index.html"
 #define HANDBOOK_LOCATION2 "/usr/share/doc/mtpaint/index.html"
 

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -425,7 +425,7 @@ void init_factions()
 		{"View filesystem data (xterm)", "xterm -hold -e ls -l %f"},
 		{"Edit in Gimp", "gimp %f"},
 		{"View in GQview", "gqview %f"},
-		{"Print image", "kprinter %f"},
+		{"Print image", "yad --print --type IMAGE --print-add-preview --filename %f"},
 		{"Email image", "seamonkey -compose attachment=file://%f"},
 		{"Send image to Firefox", "firefox %f"},
 		{"Send image to OpenOffice", "soffice %f"},


### PR DESCRIPTION
This is related to submitting my flatpak package to the Flathub repository.
https://github.com/flathub/flathub/pull/847
https://github.com/scx/flathub/tree/com.github.wjaguar.mtPaint
https://github.com/scx/mtpaint-flatpak
https://github.com/wjaguar/mtPaint/issues/31

## 1. Replace png_set_gray_1_2_4_to_8 with png_set_expand_gray_1_2_4_to_8

https://github.com/scx/mtPaint/commit/c1dd14d7b3ecc5e182f701ba4a8194ffccf273c0

The function `png_set_gray_1_2_4_to_8()` was removed from **libpng**. It has been deprecated since libpng-1.0.18 and 1.2.9, when it was replaced with `png_set_expand_gray_1_2_4_to_8()` because the former function also expanded palette images.

https://libpng.sourceforge.io/ANNOUNCE-1.4.0.txt

```
# grep -HER 'png_set_(expand_)?gray_1_2_4_to_8' /usr/include/libpng*/
/usr/include/libpng15/png.h:PNG_EXPORT(27, void, png_set_expand_gray_1_2_4_to_8, (png_structp png_ptr));
```

Equivalent in my flatpak package:
https://github.com/scx/mtpaint-flatpak/blob/bbbb459ab768b80b5edf4b28c4b3543979cc93f4/mtPaint.yaml#L53-L60
https://github.com/scx/mtpaint-flatpak/blob/bbbb459ab768b80b5edf4b28c4b3543979cc93f4/mtpaint-3.31-png.patch

See also:
https://src.fedoraproject.org/rpms/mtpaint/blob/f175c6a6b4e56bca4f053e608200c7023d33ccef/f/mtpaint.spec#_16
https://src.fedoraproject.org/rpms/mtpaint/blob/f175c6a6b4e56bca4f053e608200c7023d33ccef/f/mtpaint-3.31-png.patch

## 2. Include <locale.h> to avoid error: 'LC_ALL' undeclared

https://github.com/scx/mtPaint/commit/e7e14dd4acc7bcc9bfbb31d664ff941cad12fcad

`LC_ALL` needs `locale.h`.

http://repo-test.flathub.org:8010/#/builders/6/builds/1915
http://repo-test.flathub.org:8010/api/v2/logs/37486/raw
```
mainwindow.c:5654:12: error: ‘LC_ALL’ undeclared (first use in this function)
  setlocale(LC_ALL, txt);
```

Equivalent in my flatpak package:
https://github.com/scx/mtpaint-flatpak/blob/bbbb459ab768b80b5edf4b28c4b3543979cc93f4/mtPaint.yaml#L64-L66
https://github.com/scx/mtpaint-flatpak/blob/bbbb459ab768b80b5edf4b28c4b3543979cc93f4/mtpaint-3.49.13-include-locale.patch#L8

See also:
https://github.com/zfsonlinux/zfs/commit/92e91da20839ee50536223bedf2ba4fb7d2fae71
https://bugs.launchpad.net/lightdm-gtk-greeter/+bug/999438

## 3. Replace firefox by xdg-open

https://github.com/scx/mtPaint/commit/e5b461cb0cb69a02b543c892f9aaf7f593d9b3fb

`xdg-open` opens a file or URL in the user's preferred application. If a URL is provided the URL will be opened in the user's preferred web browser. If a file is provided the file will be opened in the preferred application for files of that type. xdg-open supports file, ftp, http and https URLs.

Equivalent in my flatpak package:
https://github.com/scx/mtpaint-flatpak/blob/bbbb459ab768b80b5edf4b28c4b3543979cc93f4/mtPaint.yaml#L67-L70
https://github.com/scx/mtpaint-flatpak/blob/bbbb459ab768b80b5edf4b28c4b3543979cc93f4/mtpaint-3.49.13-spawn-doc.patch#L11

See also:
https://src.fedoraproject.org/rpms/mtpaint/blob/f175c6a6b4e56bca4f053e608200c7023d33ccef/f/mtpaint.spec#_15
https://src.fedoraproject.org/rpms/mtpaint/blob/f175c6a6b4e56bca4f053e608200c7023d33ccef/f/mtpaint-3.40-xdg-open.patch

## 4. Replace kprinter by yad

https://github.com/scx/mtPaint/commit/7e88feb698fb1cb9138be6feeffca28dae24f0a0

`kprinter` is part of `kdebase3`, so it's really outdated now.
https://bugzilla.redhat.com/show_bug.cgi?id=964588

In KDE 3 KPrinter was responsible for printing of KDE applications, but other programs used it as well: if they had no own printing configuration but the possibility to add a generic command (like lp/lpr) they were often configured to print against the KPrinter command. KPrinter took the printed file and provided the the user a modern and flexible graphical user interface dialog to pick the preferred printer, change the printer configuration and so on.

With the transition to KDE 4 KPrinter vanished in favor of the Qt print dialog options, which worked only for Qt/KDE programs. All other programs outside Qt/KDE which relied on KPrinter as a drop-in command line tool were at a loss.
https://liquidat.wordpress.com/2014/02/18/kprinter-available-for-kde-4/

Although there is **KPrinter4** for KDE 4, it has not gained much popularity. What is worse, its development has stuck in 2014.
https://github.com/credativ/kprinter4

Equivalent in my flatpak package:
https://github.com/scx/mtpaint-flatpak/blob/bbbb459ab768b80b5edf4b28c4b3543979cc93f4/mtPaint.yaml#L71-L74
https://github.com/scx/mtpaint-flatpak/blob/bbbb459ab768b80b5edf4b28c4b3543979cc93f4/mtpaint-3.49.13-spawn-commands.patch#L18

See also:
https://src.fedoraproject.org/rpms/mtpaint/blob/f175c6a6b4e56bca4f053e608200c7023d33ccef/f/mtpaint.spec#_18
https://src.fedoraproject.org/rpms/mtpaint/blob/f175c6a6b4e56bca4f053e608200c7023d33ccef/f/mtpaint-3.40-yad.patch
https://bugzilla.redhat.com/show_bug.cgi?id=964588#c10

## 5. Update desktop file

https://github.com/scx/mtPaint/commit/464a315f18c5843b1beb42b31db95a1937c74d78

Add `StartupWMClass` entry.

If specified, it is known that the application will map at least one window with the given string as its WM class or WM name hint (see the Startup Notification Protocol Specification for more details).

Equivalent in my flatpak package:
https://github.com/scx/mtpaint-flatpak/blob/bbbb459ab768b80b5edf4b28c4b3543979cc93f4/mtPaint.yaml#L82-L85

See also:
https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#id1341
https://www.freedesktop.org/wiki/Specifications/startup-notification-spec

## 6. Add AppData file

https://github.com/scx/mtPaint/commit/f0d23985098390d01db031d6681cd08056c3d789

Register as an application to be visible in the software center.

You should also consider changing [application id](https://github.com/scx/mtpaint-flatpak/blob/bbbb459ab768b80b5edf4b28c4b3543979cc93f4/mtpaint.appdata.xml#L8), as well as renaming AppData, [desktop](https://github.com/scx/mtpaint-flatpak/blob/bbbb459ab768b80b5edf4b28c4b3543979cc93f4/mtpaint.appdata.xml#L20) and icon file.
https://github.com/flathub/flathub/wiki/AppData-Guidelines#id
Although It is not required, it is highly recommended.

Equivalent in my flatpak package:
https://github.com/scx/mtpaint-flatpak/blob/bbbb459ab768b80b5edf4b28c4b3543979cc93f4/mtPaint.yaml#L50-L52
https://github.com/scx/mtpaint-flatpak/blob/bbbb459ab768b80b5edf4b28c4b3543979cc93f4/mtpaint.appdata.xml

See also:
https://src.fedoraproject.org/rpms/mtpaint/blob/f175c6a6b4e56bca4f053e608200c7023d33ccef/f/mtpaint.spec#_88
https://github.com/flathub/flathub/wiki/AppData-Guidelines
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-releases
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-provides
https://hughsie.github.io/oars

## 7. Update Makefile: Install AppData file

https://github.com/scx/mtPaint/commit/e20b84e75fa953bd3d1c7d7bd633fe3e55027702

Install AppData file in the right directory.

Equivalent in my flatpak package:
https://github.com/scx/mtpaint-flatpak/blob/bbbb459ab768b80b5edf4b28c4b3543979cc93f4/mtPaint.yaml#L100-L101

See also:
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location
https://github.com/flatpak/flatpak/issues/30
https://github.com/flatpak/flatpak-builder/issues/252#issuecomment-453067461