### PR TITLE
fix some unsafe strncpy calls

### DIFF
--- a/src/canvas.c
+++ b/src/canvas.c
@@ -2189,7 +2189,7 @@ void file_selector_x(int action_type, void **xdata)
 	case FS_PNG_SAVE:
 		tdata.fmask = FF_SAVE_MASK;
 		tdata.title = _("Save Image File");
-		if (mem_filename) strncpy(tdata.filename, mem_filename, PATHBUF);
+		if (mem_filename) strncpy0(tdata.filename, mem_filename, PATHBUF);
 		tdata.need_save = TRUE;
 		break;
 	case FS_PALETTE_LOAD:

--- a/src/layer.c
+++ b/src/layer.c
@@ -383,7 +383,7 @@ int check_layers_for_changes()		// 1=STOP, 2=IGNORE, -10=NOT CHANGED
 
 static void layer_update_filename( char *name )
 {
-	strncpy(layers_filename, name, PATHBUF);
+	strncpy0(layers_filename, name, PATHBUF);
 	layers_changed = 1;		// Forces update of titlebar
 	layers_notify_unchanged();
 }
@@ -679,7 +679,7 @@ static void parse_filename(char *dest, char *prefix, char *file, int len)
 	for (i = 0; (i < len) && (prefix[i] == file[i]); i++);
 
 	if (!i || (i == len)) /* Complete match, or no match at all */
-		strncpy(dest, file + i, PATHBUF);
+		strncpy0(dest, file + i, PATHBUF);
 	else	/* Partial match */
 	{
 		dest[0] = 0;

--- a/src/mygtk.c
+++ b/src/mygtk.c
@@ -1055,13 +1055,6 @@ char *gtkxncpy(char *dest, const char *src, int cnt, int u)
 	return (dest);
 }
 
-// Generic wrapper for strncpy(), ensuring NUL termination
-
-char *strncpy0(char *dest, const char *src, size_t size) {
-	g_strlcpy(dest, src, size);
-	return dest;
-}
-
 // A more sane replacement for strncat()
 
 char *strnncat(char *dest, const char *src, int max)

--- a/src/mygtk.c
+++ b/src/mygtk.c
@@ -1055,6 +1055,13 @@ char *gtkxncpy(char *dest, const char *src, int cnt, int u)
 	return (dest);
 }
 
+// Generic wrapper for strncpy(), ensuring NUL termination
+
+char *strncpy0(char *dest, const char *src, size_t size) {
+	g_strlcpy(dest, src, size);
+	return dest;
+}
+
 // A more sane replacement for strncat()
 
 char *strnncat(char *dest, const char *src, int max)

--- a/src/mygtk.h
+++ b/src/mygtk.h
@@ -207,7 +207,7 @@ char *gtkxncpy(char *dest, const char *src, int cnt, int u);
 
 // Generic wrapper for strncpy(), ensuring NUL termination
 
-#define strncpy0(A,B,C) (strncpy((A), (B), (C))[(C) - 1] = 0)
+char *strncpy0(char *dest, const char *src, size_t size);
 
 // A more sane replacement for strncat()
 

--- a/src/mygtk.h
+++ b/src/mygtk.h
@@ -207,7 +207,7 @@ char *gtkxncpy(char *dest, const char *src, int cnt, int u);
 
 // Generic wrapper for strncpy(), ensuring NUL termination
 
-char *strncpy0(char *dest, const char *src, size_t size);
+#define strncpy0 g_strlcpy
 
 // A more sane replacement for strncat()
 

--- a/src/png.c
+++ b/src/png.c
@@ -1131,7 +1131,7 @@ static int save_png(char *file_name, ls_settings *settings, memFILE *mf)
 		res_len = dest_len;
 		if (compress2(tmp, &res_len, settings->img[i], w,
 			settings->png_compression) != Z_OK) continue;
-		strcpy(unknown0.name, chunk_names[i]);
+		strncpy(unknown0.name, chunk_names[i], 5);
 		unknown0.data = tmp;
 		unknown0.size = res_len;
 		unknown0.location = PNG_AFTER_IDAT;

--- a/src/png.c
+++ b/src/png.c
@@ -1131,7 +1131,7 @@ static int save_png(char *file_name, ls_settings *settings, memFILE *mf)
 		res_len = dest_len;
 		if (compress2(tmp, &res_len, settings->img[i], w,
 			settings->png_compression) != Z_OK) continue;
-		strncpy(unknown0.name, chunk_names[i], 5);
+		strncpy0(unknown0.name, chunk_names[i], 5);
 		unknown0.data = tmp;
 		unknown0.size = res_len;
 		unknown0.location = PNG_AFTER_IDAT;

--- a/src/png.c
+++ b/src/png.c
@@ -1131,7 +1131,7 @@ static int save_png(char *file_name, ls_settings *settings, memFILE *mf)
 		res_len = dest_len;
 		if (compress2(tmp, &res_len, settings->img[i], w,
 			settings->png_compression) != Z_OK) continue;
-		strncpy0(unknown0.name, chunk_names[i], 5);
+		strcpy(unknown0.name, chunk_names[i]);
 		unknown0.data = tmp;
 		unknown0.size = res_len;
 		unknown0.location = PNG_AFTER_IDAT;


### PR DESCRIPTION
This fixes several compiler warnings about strncpy by replacing it with strncpy0.
Also, the `strncpy0` macro (except for the return value which is never used) was equivalent to `strlcpy` (which is included in gtk as `g_strlcpy`), so I replaced it with that.