### PR TITLE
configure: Improve C99 compatibility

### DIFF
--- a/configure
+++ b/configure
@@ -369,12 +369,13 @@ IS_LIB()
 }
 CAN_DO()
 {
-	echo "main() { $1; }" > _conf.c
+	echo "int main() { $1; }" > _conf.c
 	$MT_TESTCOMP _conf.c -o _conf.tmp > /dev/null 2>&1
 }
 HAVE_FUNC()
 {
-	CAN_DO "$1()"
+	echo "char $1 (); int main() { $1; }" > _conf.c
+	$MT_TESTCOMP _conf.c -o _conf.tmp > /dev/null 2>&1
 }
 
 HAVE_CC_VER()


### PR DESCRIPTION
C99 compilers do not necessarily recognize implicit ints, so use int explicitly as the return type of main in CAN_DO.

In HAVE_FUNC, supply a custom prototype to avoid an implicit function declaration, otherwise this test fails at compile time as well.  The same prototype declaration is used by autoconf, so future compilers are likely to remain compatible.